### PR TITLE
Add support for setting value of select

### DIFF
--- a/lib/attributes/value.js
+++ b/lib/attributes/value.js
@@ -98,6 +98,7 @@ module.exports = Base.extend({
   _elementValue: function(value) {
 
     var isCheckbox        = /checkbox/.test(this.node.type);
+    var isSelect          = /select/.test(this.node.type);
     var isRadio           = /radio/.test(this.node.type);
     var isRadioOrCheckbox = isCheckbox || isRadio;
     var hasValue          = Object.prototype.hasOwnProperty.call(this.node, "value");
@@ -106,6 +107,9 @@ module.exports = Base.extend({
     if (!arguments.length) {
       if (isCheckbox) {
         return Boolean(this.node.checked);
+      } else if (isSelect) {
+        var selected = this.node[this.node.selectedIndex];
+        return selected && selected.value;
       } else if (isInput) {
         return this.node.value || "";
       } else {
@@ -131,6 +135,9 @@ module.exports = Base.extend({
 
       if (isInput) {
         this.node.value = value;
+      } else if (isSelect) {
+        var option = this.node.querySelector('[value="' + String(value) + '"]');
+        this.node.selectedIndex = option && option.index;
       } else {
         this.node.innerHTML = value;
       }


### PR DESCRIPTION
Although `value` is not an attribute of a select element, adding this handling to the `value` attribute simplifies form building, where all inputs, checkboxes, and radios can easily be set with `value`.

``` html
<select value="{{ <~>gender }}">
  <option value="M">Male</option>
  <option value="F">Female</option>
</select>
```
